### PR TITLE
Fix NullRefException in operator.

### DIFF
--- a/release-notes.xml
+++ b/release-notes.xml
@@ -1,2 +1,5 @@
 <ReleaseNotes>
+  <ChangeSet>
+    <Change type="bugfix">Fixes NullReferenceException in '==' operator.</Change>
+  </ChangeSet>
 </ReleaseNotes>

--- a/src/Simplic.Geography/FederalState/FederalState.cs
+++ b/src/Simplic.Geography/FederalState/FederalState.cs
@@ -7,12 +7,12 @@ namespace Simplic.Geography
     {
         public static bool operator ==(FederalState left, FederalState right)
         {
-            return !(left is null) && left.Equals(right);
+            return (left is null && right is null) || (!(left is null) && left.Equals(right));
         }
 
         public static bool operator !=(FederalState left, FederalState right)
         {
-            return !(left is null) && !left.Equals(right);
+            return (left is null && right is null) ||  (!(left is null) && !left.Equals(right));
         }
 
         public Guid Guid { get; set; } = Guid.NewGuid();

--- a/src/Simplic.Geography/FederalState/FederalState.cs
+++ b/src/Simplic.Geography/FederalState/FederalState.cs
@@ -7,12 +7,12 @@ namespace Simplic.Geography
     {
         public static bool operator ==(FederalState left, FederalState right)
         {
-            return left.Equals(right);
+            return !(left is null) && left.Equals(right);
         }
 
         public static bool operator !=(FederalState left, FederalState right)
         {
-            return !left.Equals(right);
+            return !(left is null) && !left.Equals(right);
         }
 
         public Guid Guid { get; set; } = Guid.NewGuid();

--- a/src/simplic-geography.sln
+++ b/src/simplic-geography.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ENV", "ENV", "{C028B279-B5C
 		..\.gitignore = ..\.gitignore
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\README.md = ..\README.md
+		..\release-notes.xml = ..\release-notes.xml
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simplic.Geography.Service", "Simplic.Geography.Service\Simplic.Geography.Service.csproj", "{FC3D0FE3-14D1-43E8-8E13-30B38A530973}"

--- a/test/Simplic.Geography.Test/FederalState_Equal.cs
+++ b/test/Simplic.Geography.Test/FederalState_Equal.cs
@@ -8,6 +8,43 @@ namespace Simplic.Geography.Test
     public class FederalState_Equal
     {
         [TestMethod]
+        public void FederalTest_IsNull()
+        {
+            FederalState s1 = null;
+            FederalState s2 = null;
+
+            Assert.AreEqual(s1, s2);
+            Assert.IsTrue(s1 == s2);
+        }
+
+        [TestMethod]
+        public void FederalTest_IsNull2()
+        {
+            var testId = Guid.NewGuid();
+
+            var s1 = new FederalState();
+            s1.Guid = testId;
+            FederalState s2 = null;
+
+            Assert.AreNotEqual(s1, s2);
+            Assert.IsFalse(s1 == s2);
+        }
+
+        [TestMethod]
+        public void FederalTest_IsNull3()
+        {
+            var testId = Guid.NewGuid();
+
+            FederalState s1 = null;
+            var s2 = new FederalState();
+            s2.Guid = testId;
+
+            Assert.AreNotEqual(s1, s2);
+            Assert.IsFalse(s1 == s2);
+        }
+
+
+        [TestMethod]
         public void FederalTest_IsEqual()
         {
             var testId = Guid.NewGuid();

--- a/test/Simplic.Geography.Test/FederalState_Equal.cs
+++ b/test/Simplic.Geography.Test/FederalState_Equal.cs
@@ -7,6 +7,9 @@ namespace Simplic.Geography.Test
     [TestClass]
     public class FederalState_Equal
     {
+        /// <summary>
+        /// Tests the comparison when both objects are null.
+        /// </summary>
         [TestMethod]
         public void FederalTest_IsNull()
         {
@@ -17,27 +20,33 @@ namespace Simplic.Geography.Test
             Assert.IsTrue(s1 == s2);
         }
 
+        /// <summary>
+        /// Tests the comparison when the first object is null.
+        /// </summary>
         [TestMethod]
         public void FederalTest_IsNull2()
         {
-            var testId = Guid.NewGuid();
-
-            var s1 = new FederalState();
-            s1.Guid = testId;
+            var s1 = new FederalState
+            {
+                Guid = Guid.NewGuid(),
+            };
             FederalState s2 = null;
 
             Assert.AreNotEqual(s1, s2);
             Assert.IsFalse(s1 == s2);
         }
 
+        /// <summary>
+        /// Tests the comparison when the second object is null.
+        /// </summary>
         [TestMethod]
         public void FederalTest_IsNull3()
         {
-            var testId = Guid.NewGuid();
-
             FederalState s1 = null;
-            var s2 = new FederalState();
-            s2.Guid = testId;
+            var s2 = new FederalState
+            {
+                Guid = Guid.NewGuid()
+            };
 
             Assert.AreNotEqual(s1, s2);
             Assert.IsFalse(s1 == s2);


### PR DESCRIPTION
Changed the federalstate so it no longer leads to a NullReferenceException when its null and is compared with the '==' operator.